### PR TITLE
Add base documentation functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tachyons-cli",
   "description": "Postprocess tachyons stylesheets",
   "author": "John Otander",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "main": "index.js",
   "bin": {
     "tachyons": "cli.js"
@@ -11,7 +11,8 @@
     "node": ">=4"
   },
   "files": [
-    "cli.js"
+    "cli.js",
+    "templates"
   ],
   "scripts": {
     "test": "ava"
@@ -36,9 +37,12 @@
     "chalk": "^1.1.1",
     "css-mqpacker": "^4.0.0",
     "cssnano": "^3.3.1",
+    "cssstats": "^2.1.2",
     "file-exists": "^0.1.1",
+    "immutable-css": "^1.0.1",
     "is-blank": "^1.0.0",
     "is-present": "^1.0.0",
+    "lodash": "^3.10.1",
     "meow": "^3.4.2",
     "mkdirp": "^0.5.1",
     "postcss": "^5.0.10",
@@ -46,10 +50,12 @@
     "postcss-css-variables": "^0.5.0",
     "postcss-custom-media": "^5.0.0",
     "postcss-discard-comments": "^2.0.2",
+    "postcss-get-variables": "0.0.1",
     "postcss-import": "^7.1.0"
   },
   "devDependencies": {
     "ava": "*",
-    "pify": "^2.2.0"
+    "pify": "^2.2.0",
+    "tachyons-type-scale": "^3.1.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -13,17 +13,20 @@ npm install --g tachyons-cli
 ```sh
 $ tachyons --help
 
-  Postprocess tachyons stylesheets
+  Postprocess tachyons stylesheets and, if you wish, generate docs
 
   Usage
     $ tachyons <input.css>
 
   Options
     -m, --minify Minify the output stylesheet
+    --generate-docs Generate documentation for a given module
+    --package The path to the module package to be documented
 
   Example
     $ tachyons src/tachyons.css > dist/c.css
     $ tachyons -m src/tachyons.css > dist/c.css
+    $ tachyons src/tachyons-type-scale.css --generate-docs --package=./package.json > readme.md
 ```
 
 ## License

--- a/templates/readme.md
+++ b/templates/readme.md
@@ -1,0 +1,37 @@
+# <%= module.name %> <%= module.version %>
+
+<%= module.description %>
+
+### Stats
+
+---|---|---
+<%= stats.gzipSize %> bytes | <%= stats.selectors.total %> selectors | <%= stats.declarations.total %> declarations
+
+## Install
+
+#### With [npm](https://npmjs.com)
+
+```
+npm install --save-dev <%= module.name %>
+```
+
+#### With Git
+
+```
+git clone https://github.com/tachyons-css/<%= module.name %>
+```
+
+## The Code
+
+```css
+<%= srcCss %>
+```
+
+### Authors
+
+* [mrmrs](http://mrmrs.io)
+* [johno](http://johnotander.com)
+
+## License
+
+MIT

--- a/test/fixtures/output.md
+++ b/test/fixtures/output.md
@@ -1,0 +1,65 @@
+# tachyons-type-scale 3.1.0
+
+Performance based css module.
+
+### Stats
+
+---|---|---
+205 bytes | 25 selectors | 24 declarations
+
+## Install
+
+#### With [npm](https://npmjs.com)
+
+```
+npm install --save-dev tachyons-type-scale
+```
+
+#### With Git
+
+```
+git clone https://github.com/tachyons-css/tachyons-type-scale
+```
+
+## The Code
+
+```css
+.mega{ font-size:4rem; }
+.f1{ font-size:2rem; }
+.f2{ font-size:1.5rem; }
+.f3{ font-size:1.25rem; }
+.f4{ font-size:1rem; }
+.f5,
+.small{ font-size:.85rem; }
+@media screen and (min-width: 48em){
+ .mega-ns{ font-size:4rem; }
+ .f1-ns{ font-size:2rem; }
+ .f2-ns{ font-size:1.5rem; }
+ .f3-ns{ font-size:1.25em; }
+ .f4-ns{ font-size:1rem; }
+ .f5-ns{ font-size:.85rem; } }
+@media screen and (min-width: 48em) and (max-width: 64em){
+ .mega-m{ font-size:4rem; }
+ .f1-m{ font-size:2rem; }
+ .f2-m{ font-size:1.5rem; }
+ .f3-m{ font-size:1.25rem; }
+ .f4-m{ font-size:1rem; }
+ .f5-m{ font-size:.85rem; } }
+@media screen and (min-width: 64em){
+ .mega-l{ font-size:4rem; }
+ .f1-l{ font-size:2rem; }
+ .f2-l{ font-size:1.5rem; }
+ .f3-l{ font-size:1.25rem; }
+ .f4-l{ font-size:1rem; }
+ .f5-l{ font-size:.85rem; } }
+
+```
+
+### Authors
+
+* [mrmrs](http://mrmrs.io)
+* [johno](http://johnotander.com)
+
+## License
+
+MIT

--- a/test/test.js
+++ b/test/test.js
@@ -3,9 +3,23 @@ import test from 'ava'
 import pify from 'pify'
 import childProcess from 'child_process'
 
-const output = fs.readFileSync('test/fixtures/output.css', 'utf8').trim()
+const cssOutput = fs.readFileSync('fixtures/output.css', 'utf8').trim()
+const docsOutput = fs.readFileSync('fixtures/output.md', 'utf8').trim()
 
-test(async t => {
-  const stdout = await pify(childProcess.execFile)('./cli.js', ['test/fixtures/input.css'])
-  t.same(stdout.trim(), output)
+test('processes source code', async t => {
+  const stdout = await pify(childProcess.execFile)('../cli.js', ['fixtures/input.css'], { cwd: __dirname })
+  t.same(stdout.trim(), cssOutput)
+})
+
+test('documents a module', async t => {
+  const stdout = await pify(childProcess.execFile)(
+    '../cli.js', [
+      '../node_modules/tachyons-type-scale/src/tachyons-type-scale.css',
+      '--generate-docs',
+      '--package=./node_modules/tachyons-type-scale/package.json',
+      '--template=../templates/readme.md'
+    ]
+  )
+
+  t.same(stdout.trim(), docsOutput)
 })


### PR DESCRIPTION
:dancers: :dancers: :dancers: :dancers: 

This adds the following command

```sh
tachyons src/tachyons-type-scale.css --generate-docs --package=./package.json
```

This command reads in source CSS and a package to generate
documentation based on templates/readme.md. The templating uses lodash,
and the CSS stats are added to the readme as well.

I've also added a rudimentary test to ensure the docs generation is
working as expected (which is also why I added the tachyons-type-scale
dev dependency).

I've also bumped a minor version to `0.2.0`.

TODO

* Add immutable-css linting
* Add variables documentation

***

Add basic test and templating functionality

Add package to grab variables

Add io redirection example to docs example