### PR TITLE
Improve the CSS and markdown output

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -10,10 +10,12 @@ const isBlank = require('is-blank')
 const isPresnet = require('is-present')
 const fileExists = require('file-exists')
 const cssstats = require('cssstats')
+const trailingLines = require('single-trailing-newline')
 
 const postcss = require('postcss')
 const cssnano = require('cssnano')
 const queries = require('css-mqpacker')
+const perfect = require('perfectionist')
 const prefixer = require('autoprefixer')
 const atImport = require('postcss-import')
 const media = require('postcss-custom-media')
@@ -54,11 +56,12 @@ if (isBlank(inputFile)) {
 }
 
 let plugins = [
-  atImport(), vars(), conditionals(), media(), rmComments(), queries()
+  atImport(), vars(), conditionals(), media(), queries(), perfect({ format: 'compact' })
 ]
 
 if (cli.flags.minify) {
   plugins.push(cssnano())
+  plugins.push(rmComments())
 }
 
 const input = fs.readFileSync(inputFile, 'utf8')
@@ -75,13 +78,13 @@ postcss(plugins).process(input, {
     const md = tpl({
       module: pkg,
       stats: stats,
-      srcCss: result.css
+      srcCss: trailingLines(result.css)
     })
 
-    console.log(md)
+    console.log(trailingLines(md))
     process.exit(0)
   } else {
-    console.log(result.css)
+    console.log(trailingLines(result.css))
     process.exit(0)
   }
 })

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tachyons-cli",
   "description": "Postprocess tachyons stylesheets",
   "author": "John Otander",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "index.js",
   "bin": {
     "tachyons": "cli.js"
@@ -45,13 +45,15 @@
     "lodash": "^3.10.1",
     "meow": "^3.4.2",
     "mkdirp": "^0.5.1",
+    "perfectionist": "^2.1.2",
     "postcss": "^5.0.10",
     "postcss-conditionals": "^2.0.0",
     "postcss-css-variables": "^0.5.0",
     "postcss-custom-media": "^5.0.0",
     "postcss-discard-comments": "^2.0.2",
     "postcss-get-variables": "0.0.1",
-    "postcss-import": "^7.1.0"
+    "postcss-import": "^7.1.0",
+    "single-trailing-newline": "^1.0.0"
   },
   "devDependencies": {
     "ava": "*",

--- a/templates/readme.md
+++ b/templates/readme.md
@@ -24,8 +24,7 @@ git clone https://github.com/tachyons-css/<%= module.name %>
 ## The Code
 
 ```css
-<%= srcCss %>
-```
+<%= srcCss %>```
 
 ### Authors
 
@@ -35,3 +34,6 @@ git clone https://github.com/tachyons-css/<%= module.name %>
 ## License
 
 MIT
+
+
+

--- a/test/fixtures/output.css
+++ b/test/fixtures/output.css
@@ -1,12 +1,26 @@
-.bg-cv{               background-size:cover; }
-  .bg-cn{               background-size:contain; }
-  @media screen and (min-width: 30em){
-               .bg-cv-ns{               background-size:cover; }
-               .bg-cn-ns{               background-size:contain; } }
-  @media screen and (min-width: 30em) and (max-width: 60em){
-               .bg-cv-m{               background-size:cover; }
-               .bg-cn-m{               background-size:contain; } }
-  @media screen and (min-width: 60em){
-               .bg-cv-l{               background-size:cover; }
-               .bg-cn-l{               background-size:contain; } }
-
+/*
+   BACKGROUND SIZE
+   Base:
+    bg = background-size
+   Modifiers:
+    cv = cover
+    cn = contain
+   Media Query Extensions:
+     -ns = not-small
+     -m  = medium
+     -l  = large
+*/
+.bg-cv { background-size: cover; }
+.bg-cn { background-size: contain; }
+@media screen and (min-width: 30em) {
+ .bg-cv-ns { background-size: cover; }
+ .bg-cn-ns { background-size: contain; }
+}
+@media screen and (min-width: 30em) and (max-width: 60em) {
+ .bg-cv-m { background-size: cover; }
+ .bg-cn-m { background-size: contain; }
+}
+@media screen and (min-width: 60em) {
+ .bg-cv-l { background-size: cover; }
+ .bg-cn-l { background-size: contain; }
+}

--- a/test/fixtures/output.md
+++ b/test/fixtures/output.md
@@ -5,7 +5,7 @@ Performance based css module.
 ### Stats
 
 ---|---|---
-205 bytes | 25 selectors | 24 declarations
+229 bytes | 25 selectors | 24 declarations
 
 ## Install
 
@@ -24,35 +24,41 @@ git clone https://github.com/tachyons-css/tachyons-type-scale
 ## The Code
 
 ```css
-.mega{ font-size:4rem; }
-.f1{ font-size:2rem; }
-.f2{ font-size:1.5rem; }
-.f3{ font-size:1.25rem; }
-.f4{ font-size:1rem; }
-.f5,
-.small{ font-size:.85rem; }
-@media screen and (min-width: 48em){
- .mega-ns{ font-size:4rem; }
- .f1-ns{ font-size:2rem; }
- .f2-ns{ font-size:1.5rem; }
- .f3-ns{ font-size:1.25em; }
- .f4-ns{ font-size:1rem; }
- .f5-ns{ font-size:.85rem; } }
-@media screen and (min-width: 48em) and (max-width: 64em){
- .mega-m{ font-size:4rem; }
- .f1-m{ font-size:2rem; }
- .f2-m{ font-size:1.5rem; }
- .f3-m{ font-size:1.25rem; }
- .f4-m{ font-size:1rem; }
- .f5-m{ font-size:.85rem; } }
-@media screen and (min-width: 64em){
- .mega-l{ font-size:4rem; }
- .f1-l{ font-size:2rem; }
- .f2-l{ font-size:1.5rem; }
- .f3-l{ font-size:1.25rem; }
- .f4-l{ font-size:1rem; }
- .f5-l{ font-size:.85rem; } }
+/*
 
+   TYPE SCALE
+
+*/
+.mega { font-size: 4rem; }
+.f1 { font-size: 2rem; }
+.f2 { font-size: 1.5rem; }
+.f3 { font-size: 1.25rem; }
+.f4 { font-size: 1rem; }
+.f5, .small { font-size: .85rem; }
+@media screen and (min-width: 48em) {
+ .mega-ns { font-size: 4rem; }
+ .f1-ns { font-size: 2rem; }
+ .f2-ns { font-size: 1.5rem; }
+ .f3-ns { font-size: 1.25em; }
+ .f4-ns { font-size: 1rem; }
+ .f5-ns { font-size: .85rem; }
+}
+@media screen and (min-width: 48em) and (max-width: 64em) {
+ .mega-m { font-size: 4rem; }
+ .f1-m { font-size: 2rem; }
+ .f2-m { font-size: 1.5rem; }
+ .f3-m { font-size: 1.25rem; }
+ .f4-m { font-size: 1rem; }
+ .f5-m { font-size: .85rem; }
+}
+@media screen and (min-width: 64em) {
+ .mega-l { font-size: 4rem; }
+ .f1-l { font-size: 2rem; }
+ .f2-l { font-size: 1.5rem; }
+ .f3-l { font-size: 1.25rem; }
+ .f4-l { font-size: 1rem; }
+ .f5-l { font-size: .85rem; }
+}
 ```
 
 ### Authors


### PR DESCRIPTION
- Ensure there's only one trailing newline.
- Only remove comments when minifying.
- Use `perfectionist` to format CSS in a compact format