### PR TITLE
Add node v6 to travis, remove single trailing whitespace in cli.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
   - '4'
+  - '6'

--- a/cli.js
+++ b/cli.js
@@ -39,7 +39,7 @@ const cli = meow(`
     r: 'repeat',
     a: 'authors',
     n: 'new'
-  } 
+  }
 })
 
 const inputFile = cli.input[0]


### PR DESCRIPTION
Two tiny changes, with the first (added node 6 to the CI test matrix) having tangible benefits. The latter was a single trailing space that was automatically stripped in Vim.